### PR TITLE
Fixed link to GitHub in footer

### DIFF
--- a/src/code-snippet/index.js
+++ b/src/code-snippet/index.js
@@ -25,7 +25,7 @@ export default ({ operation, activeLibrary, onLibraryChange }) => {
       const demoUrl = `http://dev.apollodata.com/frontpage-${library}-app-${operation}/`;
 
       // these two are completely standard
-      const githubUrl = `https://github.com/apollostack/frontpage-${activeLibrary}-app`;
+      const githubUrl = `https://github.com/apollographql/frontpage-${activeLibrary}-app`;
       const docsUrl = `http://dev.apollodata.com/${activeLibrary}`;
 
       return (


### PR DESCRIPTION
The link in the footer pointed to the old "apollostack" GitHub organization, I was looking for the repo from the website and clicked on it. Thought I'd save the next guy that one additional click.