### PR TITLE
replace apollostack with current apollodata/apollographql links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ url_youtube: https://www.youtube.com/c/ApolloGraphQL
 
 # Social
 twitter_username: apollographql
-github_username:  apollostack
+github_username:  apollographql
 
 exclude:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "version": "1.0.0",
-  "description": "Available at [apollostack.com](http://apollostack.com).",
+  "description": "Available at [apollodata.com](http://apollodata.com).",
   "main": "gruntfile.js",
   "dependencies": {
     "grunt": "^1.0.1",
@@ -76,7 +76,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/apollostack/apollo/"
+    "url": "https://github.com/apollographql/"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
@stubailo here is the footer link fix.

Also note: this replaces the ‘apollostack’ usage throughout the entire project, specifically, the `package.json` file.

if you’d prefer the repo.url to point to `apollographql/dev.apollodata.com` let me know and I’ll PR the change.